### PR TITLE
Addressing issues raised May 3rd in commit #49e0b5d8a where some plug…

### DIFF
--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/Settings.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/Settings.java
@@ -387,4 +387,7 @@ public final class Settings {
         return plugin.getConfig().getStringList("disabled-commands");
     }
 
+    public boolean untagOnPluginTeleport() {
+        return plugin.getConfig().getBoolean("untag-on-plugin-teleport");
+    }
 }

--- a/CombatTagPlus/src/main/java/net/minelink/ctplus/listener/PlayerListener.java
+++ b/CombatTagPlus/src/main/java/net/minelink/ctplus/listener/PlayerListener.java
@@ -261,7 +261,10 @@ public final class PlayerListener implements Listener {
                 return;
             case PLUGIN:
             case UNKNOWN:
-                plugin.getTagManager().untag(player.getUniqueId());
+                // Optionally untag on PLUGIN or UNKNOWN
+                if (plugin.getSettings().untagOnPluginTeleport()) {
+                    plugin.getTagManager().untag(player.getUniqueId());
+                }
                 return;
         }
 

--- a/CombatTagPlus/src/main/resources/config.yml
+++ b/CombatTagPlus/src/main/resources/config.yml
@@ -70,6 +70,9 @@ disable-flying-message: '&bFlying &cis disabled in combat.'
 # Prevent tagged players from teleporting during combat.
 disable-teleportation: false
 
+# Optionally untag a player if tagged and teleportation is caused by PLUGIN or UNKNOWN
+untag-on-plugin-teleport: false
+
 # This message is displayed when a player attempts to teleport within pvp if teleportation is disabled in pvp.
 disable-teleportation-message: '&bTeleportation &cis disabled in combat.'
 


### PR DESCRIPTION
…ins like NoCheatPlus and WorldBorder would result in easy glitches for players to avoid combattag as both can cause somewhat frequent UNKNOWN and PLUGIN teleport events.
